### PR TITLE
Fix Side-Nav. Panel HRI descriptive text

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 name: Documentation for the Health Record Ingestion service
 title: Health Record Ingestion service
-description: The HRI is the Watson Foundation for Health deployment ready component for streaming data into the cloud.
+description: The HRI is a deployment ready service for streaming data into the cloud.
 theme: jekyll-theme-dinky
 github:
   repository_url: https://github.com/Alvearie/HRI


### PR DESCRIPTION
This is just a quik fix for the HRI description text in the _config.yml that shows up in the Left-Side Panel.

Signed-off-by: Aram Openden <Aram.Openden1@ibm.com>